### PR TITLE
Support python 3.8 typing syntax

### DIFF
--- a/src/toolong/cli.py
+++ b/src/toolong/cli.py
@@ -1,5 +1,6 @@
 from importlib.metadata import version
 import click
+from typing import List
 
 from toolong.ui import UI
 
@@ -8,7 +9,7 @@ from toolong.ui import UI
 @click.version_option(version("toolong"))
 @click.argument("files", metavar="FILE1 FILE2", nargs=-1)
 @click.option("-m", "--merge", is_flag=True, help="Merge files")
-def run(files: list[str], merge: bool):
+def run(files: List[str], merge: bool):
     """View / tail / search log files."""
     if not files:
         ctx = click.get_current_context()

--- a/src/toolong/format_parser.py
+++ b/src/toolong/format_parser.py
@@ -9,10 +9,10 @@ from rich.text import Text
 
 from toolong.highlighter import LogHighlighter
 from toolong import timestamps
-from typing import Optional
+from typing import Optional, Tuple
 
 
-ParseResult: TypeAlias = tuple[Optional[datetime], str, Text]
+ParseResult: TypeAlias = Tuple[Optional[datetime], str, Text]
 
 
 class LogFormat:

--- a/src/toolong/log_file.py
+++ b/src/toolong/log_file.py
@@ -6,7 +6,7 @@ import mmap
 import mimetypes
 import time
 from pathlib import Path
-from typing import IO, Iterable
+from typing import IO, Iterable, Tuple, List
 from threading import Event
 
 import rich.repr
@@ -138,7 +138,7 @@ class LogFile:
 
     def scan_line_breaks(
         self, batch_time: float = 0.25
-    ) -> Iterable[tuple[int, list[int]]]:
+    ) -> Iterable[Tuple[int, List[int]]]:
         """Scan the file for line breaks.
 
         Args:
@@ -154,7 +154,7 @@ class LogFile:
         log_mmap = mmap.mmap(fileno, size, prot=mmap.PROT_READ)
         rfind = log_mmap.rfind
         position = size
-        batch: list[int] = []
+        batch: List[int] = []
         append = batch.append
         get_length = batch.__len__
         monotonic = time.monotonic
@@ -172,7 +172,7 @@ class LogFile:
 
     def scan_timestamps(
         self, batch_time: float = 0.25
-    ) -> Iterable[list[tuple[int, int, float]]]:
+    ) -> Iterable[List[Tuple[int, int, float]]]:
         size = self.size
         if not size:
             return
@@ -184,7 +184,7 @@ class LogFile:
         line_no = 0
         timestamp = self.get_create_time() or datetime.utcnow()
         position = 0
-        results: list[tuple[int, int, float]] = []
+        results: List[Tuple[int, int, float]] = []
         append = results.append
         get_length = results.__len__
         while line_bytes := log_mmap.readline():

--- a/src/toolong/log_view.py
+++ b/src/toolong/log_view.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from asyncio import Lock
 from datetime import datetime
+from typing import List
 
 from rich.text import Text
 
@@ -207,7 +208,7 @@ class LogFooter(Widget):
         self.call_after_refresh(self.mount_keys)
 
     def update_meta(self) -> None:
-        meta: list[str] = []
+        meta: List[str] = []
         if self.filename:
             meta.append(self.filename)
         if self.timestamp is not None:
@@ -270,7 +271,7 @@ class LogView(Horizontal):
     can_tail: reactive[bool] = reactive(True)
 
     def __init__(
-        self, file_paths: list[str], watcher: Watcher, can_tail: bool = True
+        self, file_paths: List[str], watcher: Watcher, can_tail: bool = True
     ) -> None:
         self.file_paths = file_paths
         self.watcher = watcher

--- a/src/toolong/messages.py
+++ b/src/toolong/messages.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import List
 
 import rich.repr
 from textual.message import Message
@@ -40,7 +41,7 @@ class NewBreaks(Message):
     """New line break to add."""
 
     log_file: LogFile
-    breaks: list[int]
+    breaks: List[int]
     scanned_size: int = 0
     tail: bool = False
 

--- a/src/toolong/timestamps.py
+++ b/src/toolong/timestamps.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from datetime import datetime
 import re
-from typing import Callable, NamedTuple
+from typing import Callable, NamedTuple, Tuple
 
 
 class TimestampFormat(NamedTuple):
@@ -95,7 +95,7 @@ TIMESTAMP_FORMATS = [
 ]
 
 
-def parse(line: str) -> tuple[TimestampFormat | None, datetime | None]:
+def parse(line: str) -> Tuple[TimestampFormat | None, datetime | None]:
     """Attempt to parse a timestamp."""
     for timestamp in TIMESTAMP_FORMATS:
         regex, parse_callable = timestamp

--- a/src/toolong/ui.py
+++ b/src/toolong/ui.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from typing import List
 
 import locale
 
@@ -78,7 +79,7 @@ class UI(App):
     """The top level App object."""
 
     @classmethod
-    def sort_paths(cls, paths: list[str]) -> list[str]:
+    def sort_paths(cls, paths: List[str]) -> List[str]:
         def key(path) -> list:
             return [
                 int(token) if token.isdigit() else token.lower()
@@ -87,7 +88,7 @@ class UI(App):
 
         return sorted(paths, key=key)
 
-    def __init__(self, file_paths: list[str], merge: bool = False) -> None:
+    def __init__(self, file_paths: List[str], merge: bool = False) -> None:
         self.file_paths = self.sort_paths(file_paths)
         self.merge = merge
         self.watcher = Watcher()

--- a/src/toolong/watcher.py
+++ b/src/toolong/watcher.py
@@ -7,7 +7,7 @@ import os
 import platform
 from selectors import DefaultSelector, EVENT_READ
 from threading import Event, Thread
-from typing import Callable, TYPE_CHECKING
+from typing import Callable, TYPE_CHECKING, List
 
 
 if platform.system() == "Linux":
@@ -27,11 +27,11 @@ class WatchedFile:
     """A currently watched file."""
 
     log_file: LogFile
-    callback: Callable[[int, list[int]], None]
+    callback: Callable[[int, List[int]], None]
     error_callback: Callable[[Exception], None]
 
 
-def scan_chunk(chunk: bytes, position: int) -> list[int]:
+def scan_chunk(chunk: bytes, position: int) -> List[int]:
     """Scan line breaks in a binary chunk,
 
     Args:
@@ -41,7 +41,7 @@ def scan_chunk(chunk: bytes, position: int) -> list[int]:
     Returns:
         A list of indices with new lines.
     """
-    breaks: list[int] = []
+    breaks: List[int] = []
     offset = 0
     append = breaks.append
     while (offset := chunk.find(b"\n", offset)) != -1:
@@ -66,7 +66,7 @@ class Watcher(Thread):
     def add(
         self,
         log_file: LogFile,
-        callback: Callable[[int, list[int]], None],
+        callback: Callable[[int, List[int]], None],
         error_callback: Callable[[Exception], None],
     ) -> None:
         """Add a file to the watcher."""


### PR DESCRIPTION
Type annotations such as `tuple[...]`/`list[...]` are not yet supported in python 3.8 - instead, if you wish to support this version you can do so by switching to `Tuple[...]`/`List[...]` from the `typing` module.

![image](https://github.com/Textualize/toolong/assets/33152084/9da6e7ca-3d3b-41a4-b57c-5def0c78a1d8)

