### PR TITLE
Relax `textual` pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ documentation = "https://github.com/textualize/toolong"
 [tool.poetry.dependencies]
 python = "^3.8"
 click = "^8.1.7"
-textual = "^0.50.0"
+textual = ">=0.50.0,<1"
 typing-extensions = "^4.9.0"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
```
+ pip check
toolong 1.2.0 has requirement textual<0.51.0,>=0.50.0, but you have textual 0.51.0.
```

I'm not sure if you were intending to exclude `textual>=0.51`? Assuming that's not the case I've loosened the pin here. If `<1` is too loose, feel free to push any changes you want to this PR...