### PR TITLE
[WIP] First proof of concept for Nextflow logs

### DIFF
--- a/src/toolong/format_parser.py
+++ b/src/toolong/format_parser.py
@@ -53,6 +53,129 @@ class RegexLogFormat(LogFormat):
 
         return timestamp, line, text
 
+class NextflowRegexLogFormatOne(LogFormat):
+    REGEX = re.compile(".*?")
+    LOG_LEVELS = {
+        "DEBUG": ["dim white on black", ""],
+        "INFO": ["bold black on green", "on #042C07"],
+        "WARN": ["bold black on yellow", "on #44450E"],
+        "ERROR": ["bold black on red", "on #470005"],
+    }
+
+    highlighter = LogHighlighter()
+
+    def parse(self, line: str) -> ParseResult | None:
+        match = self.REGEX.fullmatch(line)
+        if match is None:
+            return None
+
+        text = Text.from_ansi(line)
+        groups = match.groupdict()
+#        if not text.spans:
+#            text = self.highlighter(text)
+        if date := groups.get("date", None):
+            _, timestamp = timestamps.parse(groups["date"])
+            text.highlight_words([date], "not bold magenta")
+        if thread := groups.get("thread", None):
+            text.highlight_words([thread], "blue")
+        if log_level := groups.get("log_level", None):
+            text.highlight_words([f" {log_level} "], self.LOG_LEVELS[log_level][0])
+            text.stylize_before(self.LOG_LEVELS[log_level][1])
+        if logger_name := groups.get("logger_name", None):
+            text.highlight_words([logger_name], "cyan")
+        if process_name := groups.get("process_name", None):
+            text.highlight_words([process_name], "bold cyan")
+        if message := groups.get("message", None):
+            text.highlight_words([message], 'dim' if log_level == 'DEBUG' else '')
+
+        return None, line, text
+
+
+class NextflowRegexLogFormatTwo(LogFormat):
+    REGEX = re.compile(".*?")
+    highlighter = LogHighlighter()
+
+    def parse(self, line: str) -> ParseResult | None:
+        match = self.REGEX.fullmatch(line)
+        if match is None:
+            return None
+
+        text = Text.from_ansi(line)
+        text.stylize_before("dim")
+        groups = match.groupdict()
+        if process := groups.get("process", None):
+            text.highlight_words([process], 'blue not dim')
+        if process_name := groups.get("process_name", None):
+            text.highlight_words([process_name], 'bold cyan not dim')
+
+        return None, line, text
+
+class NextflowRegexLogFormatThree(LogFormat):
+    REGEX = re.compile(".*?")
+    CHANNEL_TYPES = {
+        "(value)": "green",
+        "(cntrl)": "yellow",
+        "(queue)": "magenta",
+    }
+    highlighter = LogHighlighter()
+
+    def parse(self, line: str) -> ParseResult | None:
+        match = self.REGEX.fullmatch(line)
+        if match is None:
+            return None
+
+        text = Text.from_ansi(line)
+        groups = match.groupdict()
+        if port := groups.get("port", None):
+            text.highlight_words([port], 'blue')
+        if channel_type := groups.get("channel_type", None):
+            text.highlight_words([channel_type], self.CHANNEL_TYPES[channel_type])
+        if channel_state := groups.get("channel_state", None):
+            text.highlight_words([channel_state], 'cyan' if channel_state == 'OPEN' else 'yellow')
+        text.highlight_words(["; channel:"], 'dim')
+        if channel_name := groups.get("channel_name", None):
+            text.highlight_words([channel_name], 'cyan')
+
+        return None, line, text
+
+class NextflowRegexLogFormatFour(LogFormat):
+    REGEX = re.compile(".*?")
+    highlighter = LogHighlighter()
+
+    def parse(self, line: str) -> ParseResult | None:
+        match = self.REGEX.fullmatch(line)
+        if match is None:
+            return None
+
+        text = Text.from_ansi(line)
+        text.stylize_before("dim")
+        groups = match.groupdict()
+        text.highlight_words(["status="], 'dim')
+        if status := groups.get("status", None):
+            text.highlight_words([status], 'cyan not dim')
+
+        return None, line, text
+
+
+class NextflowRegexLogFormatFive(LogFormat):
+    REGEX = re.compile(".*?")
+    highlighter = LogHighlighter()
+
+    def parse(self, line: str) -> ParseResult | None:
+        match = self.REGEX.fullmatch(line)
+        if match is None:
+            return None
+
+        text = Text.from_ansi(line)
+        text.stylize_before("dim")
+        groups = match.groupdict()
+        if script_id := groups.get("script_id", None):
+            text.highlight_words([script_id], 'blue')
+        if script_path := groups.get("script_path", None):
+            text.highlight_words([script_path], 'magenta')
+
+        return None, line, text
+
 
 class CommonLogFormat(RegexLogFormat):
     REGEX = re.compile(
@@ -63,6 +186,36 @@ class CommonLogFormat(RegexLogFormat):
 class CombinedLogFormat(RegexLogFormat):
     REGEX = re.compile(
         r'(?P<ip>.*?) (?P<remote_log_name>.*?) (?P<userid>.*?) \[(?P<date>.*?)(?= ) (?P<timezone>.*?)\] "(?P<request_method>.*?) (?P<path>.*?)(?P<request_version> HTTP\/.*)?" (?P<status>.*?) (?P<length>.*?) "(?P<referrer>.*?)" "(?P<user_agent>.*?)" (?P<session_id>.*?) (?P<generation_time_micro>.*?) (?P<virtual_host>.*)'
+    )
+
+
+class NextflowLogFormat(NextflowRegexLogFormatOne):
+    REGEX = re.compile(
+        r'(?P<date>\w+-\d{2} \d{2}:\d{2}:\d{2}\.\d{3}) (?P<thread>\[.*\]?) (?P<log_level>\w+)\s+(?P<logger_name>[\w\.]+) - (?P<message>.*?)$'
+    )
+
+
+class NextflowLogFormatActiveProcess(NextflowRegexLogFormatTwo):
+    REGEX = re.compile(
+        r'^(?P<marker>\[process\]) (?P<process>.*?)(?P<process_name>[^:]+?)?$'
+    )
+
+
+class NextflowLogFormatActiveProcessDetails(NextflowRegexLogFormatThree):
+    REGEX = re.compile(
+        r'  (?P<port>port \d+): (?P<channel_type>\((value|queue|cntrl)\)) (?P<channel_state>\S+)\s+; channel: (?P<channel_name>.*?)$'
+    )
+
+
+class NextflowLogFormatActiveProcessStatus(NextflowRegexLogFormatFour):
+    REGEX = re.compile(
+        r'^  status=(?P<status>.*?)?$'
+    )
+
+
+class NextflowLogFormatScriptParse(NextflowRegexLogFormatFive):
+    REGEX = re.compile(
+        r'^  (?P<script_id>Script_\w+:) (?P<script_path>.*?)$'
     )
 
 
@@ -96,10 +249,15 @@ class JSONLogFormat(LogFormat):
 
 
 FORMATS = [
-    JSONLogFormat(),
-    CommonLogFormat(),
-    CombinedLogFormat(),
-    DefaultLogFormat(),
+    # JSONLogFormat(),
+    # CommonLogFormat(),
+    # CombinedLogFormat(),
+    NextflowLogFormat(),
+    NextflowLogFormatActiveProcess(),
+    NextflowLogFormatActiveProcessDetails(),
+    NextflowLogFormatActiveProcessStatus(),
+    NextflowLogFormatScriptParse(),
+    # DefaultLogFormat(),
 ]
 
 
@@ -120,4 +278,4 @@ class FormatParser:
                     del self._formats[index : index + 1]
                     self._formats.insert(0, format)
                 return parse_result
-        return None, "", Text()
+        return None, line, Text.from_ansi(line)


### PR DESCRIPTION
## Aim

Aim is to support log files from [Nextflow](https://nextflow.io/) - a workflow manager / analysis pipeline builder commonly used in bioinformatics research (eg. DNA sequencing and more). Every run produces very long and verbose `.nextflow.log` files which are great for debugging, but extremely difficult to read. Formatting would greatly help with this.

Continuing [our discussion](https://discord.com/channels/1026214085173461072/1033754296224841768/1217120518218453073) on Discord, here are the results of my very quick and dirty play with Nextflow logs this evening.

## How it looks

https://github.com/Textualize/toolong/assets/465550/7d667414-8b25-41e7-8a52-05e461242f5c

## Reproducing locally

Example log file: [.nextflow.log](https://github.com/Textualize/toolong/files/14579669/nextflow.log.txt) (renamed to make GitHub happy, typically called `.nextflow.log`, or `.nextflow.log.6` etc.)

Can generate yourself by running Nextflow:

```bash
# Install Nextflow
curl -s https://get.nextflow.io | bash
# Run a pipeline with a tiny test dataset
nextflow run nf-core/rnaseq -profile test,docker --outdir results
# Check the log
tl .nextflow.log
```


## Discussion

* Things I like
    * Formatting of the logs, I think that they look pretty good
    * Native `toolong` functionality, such as tailing, search, navigation etc.
* Things I don't like
    * My code
    * The fact that I disabled a bunch of functionality for other log types to make this work.

These logs have a few additional bits of complexity:

1. Log outputs can span multiple lines
    * Whilst looking at this during submitting the PR, I realise that anything _without_ a timestamp is a continuation of the last log message that did. It should maintain the formatting from that log level (eg. dim for debug, red background for error etc).
2. There are multiple format styles
    * Nextflow produces output in a bunch of standardised ways. I ended up writing 5 different formatters to handle the different cases
    * There can also be arbitrary unstructured output from multi-line strings. These additional 4 are effectively special cases of this.
3. Some of the formatting rules being applied by the other formatters broke stuff / make the output look worse
    * I simply turn them off in this PR, but that's obviously not a real solution
    * This would need some kind of switch mechanism to tell `toolong` that we're looking at a Nextflow log file and _only_ use that set of formatters for the rest of the session.

## Going forward

This PR is just my way of asking for advice. I'm curious to see whether you think that this could / should live within the `toolong` codebase still, or whether it should somehow extend `toolong` as a separate package / plugin. Or whether it should be destroyed with fire and never be spoken of again 🔥 