### PR TITLE
Don't run expensive regex on very long line

### DIFF
--- a/src/toolong/format_parser.py
+++ b/src/toolong/format_parser.py
@@ -47,7 +47,7 @@ class RegexLogFormat(LogFormat):
     highlighter = LogHighlighter()
 
     def parse(self, line: str) -> ParseResult | None:
-        match = self.REGEX.fullmatch(line)
+        match = self.REGEX.fullmatch(line[:1000])
         if match is None:
             return None
         groups = match.groupdict()


### PR DESCRIPTION
See https://github.com/Textualize/toolong/issues/55

@willmcgugan  1000 characters is very arbitrary but I feel like the first 1000 characters are representative enough 