### PR TITLE
Support `uvx toolong`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ textual-dev = "^1.4.0"
 
 [tool.poetry.scripts]
 tl = "toolong.cli:run"
+toolong = "toolong.cli:run"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
It is an alternative to `uvx --from toolong tl`  for those of us who forgets that it should be called `tl`, not `toolong`.

It fixes:

``` shell
$ uvx toolong
The executable `toolong` was not found.
warning: An executable named `toolong` is not provided by package `toolong`.
The following executables are provided by `toolong`:
- tl
Consider using `uvx --from toolong <EXECUTABLE_NAME>` instead.
```