### PR TITLE
Fix Very high CPU usage when piping

### DIFF
--- a/src/toolong/cli.py
+++ b/src/toolong/cli.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from importlib.metadata import version
 import os
 import sys
+import time
 
 import click
 
@@ -73,4 +74,5 @@ def run(files: list[str], merge: bool, output_merge: str) -> None:
                                 if line := os.read(sys.stdin.fileno(), 1024 * 64):
                                     temp_file.write(line)
                                 else:
+                                    time.sleep(0.005)  # sleep 5 ms to avoid maxing CPU usage
                                     break


### PR DESCRIPTION
Insert a small sleep when polling stdin

Resolves https://github.com/Textualize/toolong/issues/48

Here is how to reproduce this issue
```
$ tl --version
tl, version 1.4.0
$ echo '{"foo": "bar"}' > /tmp/log.json
$ cat  /tmp/log.json | tl
```

This is what happens in `main` now. 100% CPU usage when piping
![Screenshot 2025-01-23 at 11 34 21 AM](https://github.com/user-attachments/assets/4a47698e-48da-4bf7-bb76-85bcbdf9c657)

I added a small sleep when there is nothing to read. I tested 1 ms and 5 ms. 

1 ms used about 2% cpu.
![Screenshot 2025-01-23 at 11 34 47 AM](https://github.com/user-attachments/assets/1a9dd9c4-1e16-494f-9760-ea0ddbb9a251)

5 ms used about 0.7% cpu.
![Screenshot 2025-01-23 at 11 35 14 AM](https://github.com/user-attachments/assets/b0bbb1b5-4331-4ef3-9f71-974d65c5dddc)

I would guess 5 ms will not be very noticable, but if it is we can go down to 1.

## Testing

I tried piping in a 40MB file and did not notice any difference in performance with or without the sleep.

