### PR TITLE
Migrate Toolong to Textual 3.x compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ documentation = "https://github.com/textualize/toolong"
 [tool.poetry.dependencies]
 python = "^3.8"
 click = "^8.1.7"
-textual = "^0.58.0"
+textual = "^3.0.0"
 typing-extensions = "^4.9.0"
 
 [tool.poetry.group.dev.dependencies]

--- a/src/toolong/log_view.py
+++ b/src/toolong/log_view.py
@@ -119,7 +119,7 @@ class FooterKey(Label):
         return f"[reverse]{self.key_display}[/reverse] {self.description}"
 
     async def on_click(self) -> None:
-        await self.app.check_bindings(self.key)
+        await self.app._check_bindings(self.key)
 
 
 class MetaLabel(Label):
@@ -203,7 +203,8 @@ class LogFooter(Widget):
                 await key_container.query("*").remove()
                 bindings = [
                     binding
-                    for (_, binding) in self.app.namespace_bindings.values()
+                    for bindings_list in self.app._bindings.key_to_bindings.values()
+                    for binding in bindings_list
                     if binding.show
                 ]
 


### PR DESCRIPTION
## Summary

This PR migrates Toolong to be compatible with Textual 3.x, enabling it to work with modern Textual applications.

## Changes Made

- **Updated dependencies**: Changed textual requirement from ^0.58.0 to ^3.0.0
- **Fixed namespace_bindings API**: Replaced `self.app.namespace_bindings.values()` with `self.app._bindings.key_to_bindings.values()`
- **Fixed check_bindings API**: Replaced `await self.app.check_bindings()` with `await self.app._check_bindings()`
- **Verified batch_update compatibility**: Confirmed this API still works in Textual 3.x

## Testing

- ✅ All basic functionality tested and working
- ✅ Key bindings display correctly
- ✅ Log file viewing and navigation works
- ✅ Multi-file merge functionality works
- ✅ Live tailing functionality works
- ✅ Integration tested with real-world log files

## Motivation

This migration enables Toolong to be used in modern Textual 3.x applications, such as integration into other TUI applications for log monitoring capabilities.

## Backward Compatibility

This change breaks compatibility with Textual 0.58.x, but enables compatibility with the current Textual 3.x ecosystem. The API changes are minimal and focused on the specific incompatible methods.

## Files Changed

- `pyproject.toml`: Updated textual dependency
- `src/toolong/log_view.py`: Fixed binding API calls

The migration required only 3 lines of code changes, demonstrating the stability of the Textual API evolution.