### PR TITLE
Add suspend functionality to keybindings for `toolong`

### DIFF
--- a/src/toolong/log_view.py
+++ b/src/toolong/log_view.py
@@ -279,6 +279,7 @@ class LogView(Horizontal):
         Binding("ctrl+f", "show_find_dialog", "Find", key_display="^f"),
         Binding("slash", "show_find_dialog", "Find", key_display="^f", show=False),
         Binding("ctrl+g", "goto", "Go to", key_display="^g"),
+        Binding("ctrl+z", "suspend_process", "Suspend", key_display="^z"),
     ]
 
     show_find: reactive[bool] = reactive(False)

--- a/src/toolong/log_view.py
+++ b/src/toolong/log_view.py
@@ -279,7 +279,6 @@ class LogView(Horizontal):
         Binding("ctrl+f", "show_find_dialog", "Find", key_display="^f"),
         Binding("slash", "show_find_dialog", "Find", key_display="^f", show=False),
         Binding("ctrl+g", "goto", "Go to", key_display="^g"),
-        Binding("ctrl+z", "suspend_process", "Suspend", key_display="^z"),
     ]
 
     show_find: reactive[bool] = reactive(False)

--- a/src/toolong/ui.py
+++ b/src/toolong/ui.py
@@ -23,6 +23,7 @@ class LogScreen(Screen):
 
     BINDINGS = [
         Binding("f1", "help", "Help"),
+        Binding("ctrl+z", "suspend_process", "Suspend", key_display="^z"),
     ]
 
     CSS = """


### PR DESCRIPTION
To address #78, added 
```
        Binding("ctrl+z", "suspend_process", "Suspend", key_display="^z"),
```
to `BINDINGS` section of `log_view.py` to enable suspending/SIGSTP/^Z functionality.
Left ^z visible; did not modify help documentation.
Alternately, could change to 
```
        Binding("ctrl+z", "suspend_process", "Suspend", key_display="^z", show=False),
```
to remove from baseline display and add to help.